### PR TITLE
Save election local storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -193,16 +193,18 @@ angular.module('agora-gui-admin').config(
         }
       };
     });
-});
+  }
+);
 
 /**
  * Configure the prefix for
  */
-angular.module('agora-gui-admin').config(['localStorageServiceProvider',
+angular.module('agora-gui-admin').config(
   function(localStorageServiceProvider)
   {
     localStorageServiceProvider.setPrefix('agora-gui-admin');
-  }]);
+  }
+);
 
 
 /**

--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ angular.module(
   'angularLoad',
   'angular-date-picker-polyfill',
   'ng-autofocus',
+  'LocalStorageModule',
   'agora-gui-common'
 ]);
 
@@ -193,6 +194,16 @@ angular.module('agora-gui-admin').config(
       };
     });
 });
+
+/**
+ * Configure the prefix for
+ */
+angular.module('agora-gui-admin').config(['localStorageServiceProvider',
+  function(localStorageServiceProvider)
+  {
+    localStorageServiceProvider.setPrefix('agora-gui-admin');
+  }]);
+
 
 /**
  * IF the cookie is there we make the autologin

--- a/avAdmin/elections-api-service.js
+++ b/avAdmin/elections-api-service.js
@@ -9,6 +9,7 @@ angular.module('avAdmin')
         $i18next,
         $http,
         $cookies,
+        localStorageServiceProvider,
         $rootScope)
       {
         var backendUrl = ConfigService.electionsAPI;
@@ -36,7 +37,7 @@ angular.module('avAdmin')
                 $rootScope.$watch('currentElection', function(newv, oldv) {
                   AdminPlugins.hook('election-modified', {'old': oldv, 'el': newv});
                   if (!$rootScope.currentElection.id) {
-                    $cookies.currentElection = JSON.stringify($rootScope.currentElection);
+                    localSaveElection($rootScope.currentElection);
                   }
                 }, true);
                 $rootScope.watchingElection = true;
@@ -48,14 +49,54 @@ angular.module('avAdmin')
             electionsapi.waitingCurrent = [];
         };
 
-        if ($cookies.currentElection) {
-            console.log($cookies.currentElection);
+        if (hasSavedElection()) {
             try {
-                var el = JSON.parse($cookies.currentElection);
+                var el = getSavedElection();
+                console.log(getSavedElection());
                 electionsapi.setCurrent(el);
             } catch (e) {
-                $cookies.currentElection = electionsapi.currentElection;
+                localSaveElection(electionsapi.currentElection);
             }
+        }
+
+        /**
+         * Generates a saved election key for the local storage key value store
+         * in a secure way: the key is a cryptographically secure id, stored
+         * as a cookie.
+         */
+        function getSavedElectionKey() {
+          if (!$cookies.savedElectionKey) {
+            $cookies.savedElectionKey = "savedElectionKey_" + Random.getRandomInteger(1000000000000);
+          }
+
+          return $cookies.savedElectionKey;
+        }
+
+        /**
+         * Return the saved election in local storage if it exists or null.
+         */
+        function getSavedElection() {
+          return JSON.parse(
+            localStorageServiceProvider.get(
+              getSavedElectionKey()));
+        }
+
+        /**
+         * Saves locally the election into local storage.
+         */
+        function localSaveElection(election) {
+          localStorageServiceProvider.set(
+            getSavedElectionKey(),
+            JSON.stringify(election));
+        }
+
+        /**
+         * Return boolean that specifies if there's any saved election in local
+         * storage.
+         */
+        function hasSavedElection() {
+          return !!localStorageServiceProvider.get(
+              getSavedElectionKey());
         }
 
         function asyncElection(id) {

--- a/avAdmin/elections-api-service.js
+++ b/avAdmin/elections-api-service.js
@@ -9,9 +9,52 @@ angular.module('avAdmin')
         $i18next,
         $http,
         $cookies,
-        localStorageServiceProvider,
+        localStorageService,
         $rootScope)
       {
+
+        /**
+         * Generates a saved election key for the local storage key value store
+         * in a secure way: the key is a cryptographically secure id, stored
+         * as a cookie.
+         */
+        function getSavedElectionKey() {
+          if (!$cookies.savedElectionKey) {
+            /* jshint ignore:start */
+            $cookies.savedElectionKey = "savedElectionKey_" + sjcl.codec.base64.fromBits(sjcl.random.randomWords(8, 0));
+            /* jshint ignore:end */
+          }
+
+          return $cookies.savedElectionKey;
+        }
+
+        /**
+         * Return the saved election in local storage if it exists or null.
+         */
+        function getSavedElection() {
+          return JSON.parse(
+            localStorageService.get(
+              getSavedElectionKey()));
+        }
+
+        /**
+         * Saves locally the election into local storage.
+         */
+        function localSaveElection(election) {
+          localStorageService.set(
+            getSavedElectionKey(),
+            JSON.stringify(election));
+        }
+
+        /**
+         * Return boolean that specifies if there's any saved election in local
+         * storage.
+         */
+        function hasSavedElection() {
+          return !!localStorageService.get(
+              getSavedElectionKey());
+        }
+
         var backendUrl = ConfigService.electionsAPI;
         var electionsapi = {cache: {}, permcache: {}};
         electionsapi.waitingCurrent = [];
@@ -59,45 +102,6 @@ angular.module('avAdmin')
             }
         }
 
-        /**
-         * Generates a saved election key for the local storage key value store
-         * in a secure way: the key is a cryptographically secure id, stored
-         * as a cookie.
-         */
-        function getSavedElectionKey() {
-          if (!$cookies.savedElectionKey) {
-            $cookies.savedElectionKey = "savedElectionKey_" + Random.getRandomInteger(1000000000000);
-          }
-
-          return $cookies.savedElectionKey;
-        }
-
-        /**
-         * Return the saved election in local storage if it exists or null.
-         */
-        function getSavedElection() {
-          return JSON.parse(
-            localStorageServiceProvider.get(
-              getSavedElectionKey()));
-        }
-
-        /**
-         * Saves locally the election into local storage.
-         */
-        function localSaveElection(election) {
-          localStorageServiceProvider.set(
-            getSavedElectionKey(),
-            JSON.stringify(election));
-        }
-
-        /**
-         * Return boolean that specifies if there's any saved election in local
-         * storage.
-         */
-        function hasSavedElection() {
-          return !!localStorageServiceProvider.get(
-              getSavedElectionKey());
-        }
 
         function asyncElection(id) {
             var deferred = $q.defer();

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
     "bower_components"
   ],
   "dependencies": {
-    "avCommon": "https://github.com/agoravoting/agora-gui-common.git#next"
+    "avCommon": "https://github.com/agoravoting/agora-gui-common.git#next",
+    "angular-local-storage": "~0.2.3"
   }
 }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <!-- JS from Bower Components -->
   <script src="bower_components/avCommon/dist/libnocompat-v3.0.1.js" class="libnocompat"></script>
   <script src="bower_components/avCommon/dist/libCommon-v3.0.1.js" class="lib"></script>
-  <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
+  <script src="bower_components/angular-local-storage/dist/angular-local-storage.js" class="lib"></script>
 
   <script src="vendor/angular-date-picker-polyfill/angular-date-picker-polyfill.js" class="lib"></script>
   <script src="vendor/jquery.nanoscroller/nanoscroller.js" class="lib"></script>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <!-- JS from Bower Components -->
   <script src="bower_components/avCommon/dist/libnocompat-v3.0.1.js" class="libnocompat"></script>
   <script src="bower_components/avCommon/dist/libCommon-v3.0.1.js" class="lib"></script>
+  <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
 
   <script src="vendor/angular-date-picker-polyfill/angular-date-picker-polyfill.js" class="lib"></script>
   <script src="vendor/jquery.nanoscroller/nanoscroller.js" class="lib"></script>


### PR DESCRIPTION
When creating an election, saves it in HTML5 local storage instead of in a cookie because the cookie headers would be otherwise very large. Related trello card: https://trello.com/c/EEWKlGQ9/462-recargar-la-pagina-de-nueva-votacion-en-el-navegador-da-error-400-request-entity-too-large