### PR TITLE
fix spaces when adding from csv

### DIFF
--- a/avAdmin/admin-directives/elcensus/elcensus.js
+++ b/avAdmin/admin-directives/elcensus/elcensus.js
@@ -200,6 +200,9 @@ angular.module('avAdmin')
               if (nv.tlf) {
                 nv.tlf.replace(" ", "");
               }
+              if (nv.email) {
+                nv.email.replace(" ", "");
+              }
               cs.push({selected: false, vote: false, username: "", metadata: nv});
           });
 


### PR DESCRIPTION
When in an election with email census, in agora-gui-admin > census > add from CSV, we add a list of emails with some spaces between the emails, currently this adds the emails with the spaces and this makes login later fail.

TODO: Fix that also in authapi! @virako maybe can you do it, with a test case?