### PR TITLE
census: Add action buttons for each voter

### DIFF
--- a/avAdmin/admin-directives/elcensus/elcensus.html
+++ b/avAdmin/admin-directives/elcensus/elcensus.html
@@ -103,6 +103,7 @@
           <th ng-repeat="field in election.census.extra_fields">
             {{ field.name| htmlToText }}
           </th>
+          <th ng-i18next>avAdmin.census.actionsDropdown</th>
         </tr>
       </thead>
       <tbody ng-if="!reloadingCensus">
@@ -138,6 +139,15 @@
             </span>
           </td>
           <td ng-repeat="field in election.census.extra_fields" av-census-field>
+          </td>
+          <td class="census-actions">
+            <span ng-repeat="command in row_commands"
+                  ng-class="{'disabled': !command.enableFunc()}">
+                <a ng-click="command.actionFunc(c)">
+                  <i class="{{command.iconClass}}"
+                     tooltip="{{command.text}}"></i>
+                </a>
+            </span>
           </td>
         </tr>
       </tbody>

--- a/avAdmin/admin-directives/elcensus/elcensus.js
+++ b/avAdmin/admin-directives/elcensus/elcensus.js
@@ -19,6 +19,7 @@ angular.module('avAdmin')
   .directive(
     'avAdminElcensus',
     function(
+      $i18next,
       $window,
       $state,
       ElectionsApi,
@@ -161,6 +162,80 @@ angular.module('avAdmin')
           enableFunc: function() {
             return scope.numSelected(scope.shown()) > 0;
           }
+        }
+      ];
+
+      function selectVoter(voter) {
+        _.each(scope.election.census.voters, function (v) { v.selected = false; });
+        voter.selected = true;
+      }
+
+      scope.row_commands = [
+        {
+	  text: $i18next("avAdmin.census.activateOneAction"),
+          iconClass: 'fa fa-user',
+          actionFunc: function(voter) {
+	    selectVoter(voter);
+            $modal.open({
+              templateUrl: "avAdmin/admin-directives/elcensus/confirm-activate-people-modal.html",
+              controller: "ConfirmActivatePeopleModal",
+              size: 'lg',
+              resolve: {
+                election: function () { return scope.election; },
+                numSelectedShown: function() {
+                  return scope.numSelected(scope.shown());
+                }
+              }
+            }).result.then(scope.activateSelected);
+          },
+          enableFunc: function() { return scope.election && scope.election.id; }
+        },
+        {
+	  text: $i18next("avAdmin.census.deactivateOneAction"),
+          iconClass: 'fa fa-user-times',
+          actionFunc: function(voter) {
+	    selectVoter(voter);
+            $modal.open({
+              templateUrl: "avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.html",
+              controller: "ConfirmDeactivatePeopleModal",
+              size: 'lg',
+              resolve: {
+                election: function () { return scope.election; },
+                numSelectedShown: function() {
+                  return scope.numSelected(scope.shown());
+                }
+              }
+            }).result.then(scope.deactivateSelected);
+          },
+          enableFunc: function() { return scope.election && scope.election.id; }
+        },
+        {
+	  text: $i18next("avAdmin.census.removeCensusOneAction"),
+          iconClass: 'fa fa-trash-o',
+          actionFunc: function(voter) {
+	    selectVoter(voter);
+            $modal.open({
+              templateUrl: "avAdmin/admin-directives/elcensus/confirm-remove-people-modal.html",
+              controller: "ConfirmRemovePeopleModal",
+              size: 'lg',
+              resolve: {
+                election: function () { return scope.election; },
+                numSelectedShown: function() {
+                  return scope.numSelected(scope.shown());
+                }
+              }
+            }).result.then(scope.removeSelected);
+          },
+          enableFunc: function() { return true; }
+        },
+        {
+	  text: $i18next("avAdmin.census.sendAuthCodesOneAction"),
+          iconClass: 'fa fa-paper-plane-o',
+          actionFunc: function(voter) {
+	    selectVoter(voter);
+	    return sendAuthCodesSelected();
+          },
+          enableFunc: function() { return true; }
         }
       ];
 

--- a/avAdmin/admin-directives/elcensus/elcensus.less
+++ b/avAdmin/admin-directives/elcensus/elcensus.less
@@ -114,6 +114,21 @@
       }
     }
   }
+
+  .census-actions {
+    span {
+      margin: 10px;
+      opacity: 0;
+      font-size: large;
+    }
+
+    .disabled { display: none; }
+  }
+
+  .censustable tr:hover .census-actions span {
+    opacity: 1;
+    transition: opacity 0.5s;
+  }
 }
 
 .export-all-census-modal progressbar {

--- a/locales/en.json
+++ b/locales/en.json
@@ -397,6 +397,11 @@
         "deactivatedCensusSuccessfully": "Deactivated selected people in census successfully",
         "sentCodesSuccessfully": "Sent authentication codes successfully",
 
+        "activateOneAction": "Activate",
+        "deactivateOneAction": "Deactivate",
+        "removeCensusOneAction": "Remove",
+        "sendAuthCodesOneAction": "Send auth codes",
+
         "voted": "voted",
         "notVoted": "not voted",
         "votedColumnHeader": "Voted?",

--- a/locales/es.json
+++ b/locales/es.json
@@ -396,6 +396,11 @@
         "deactivatedCensusSuccessfully": "Se desactivaron las personas seleccionadas correctamente",
         "sentCodesSuccessfully": "Enviados los códigos de autenticación correctamente",
 
+        "activateOneAction": "Activar",
+        "deactivateOneAction": "Desactivar",
+        "removeCensusOneAction": "Eliminar",
+        "sendAuthCodesOneAction": "Enviar código de autenticación",
+
         "voted": "votó",
         "notVoted": "no votó",
         "votedColumnHeader": "Votó?",


### PR DESCRIPTION
This patch adds actions buttons for each row in the census table.
Buttons added are Activate, Deactivate, Remove and Send auth codes.

These buttons select the row and then call the same action as actions
dropdown, all other rows are deselected so this should work similar to
select only one row and click in the actions dropdown.

Buttons are hidden by default and showed on hover the row.

I've add translations for these actions but not for gl and ca.