### PR TITLE
census: Comment for activate/deactivate actions

### DIFF
--- a/avAdmin/admin-directives/activity-log/activity-log.html
+++ b/avAdmin/admin-directives/activity-log/activity-log.html
@@ -144,10 +144,10 @@
             </div>
           </td>
           <td>
-            <div ng-if="!!obj.metadata.comment">
-                {{obj.metadata.comment}}
+            <div ng-if="!!obj.metadatacomment">
+                {{obj.metadatacomment}}
             </div>
-            <div ng-if="!obj.metadata.comment">-</div>
+            <div ng-if="!obj.metadatacomment">-</div>
           </td>
         </tr>
       </tbody>

--- a/avAdmin/admin-directives/activity-log/activity-log.js
+++ b/avAdmin/admin-directives/activity-log/activity-log.js
@@ -69,6 +69,10 @@ angular.module('avAdmin')
                     scope.reloadingActivity = false;
                 }
                 _.each(data.activity, function (obj) {
+		    // I'm doing this because if we try to get this from the
+		    // template, doesn't work: {{obj.metadata.comment}} is
+		    // always undefined
+                    obj.metadatacomment = obj.metadata.comment;
                     scope.activity.push(obj);
                 });
 

--- a/avAdmin/admin-directives/elcensus/confirm-activate-people-modal.html
+++ b/avAdmin/admin-directives/elcensus/confirm-activate-people-modal.html
@@ -9,11 +9,11 @@
   </h4>
 </div>
 <div class="modal-body">
-  <p>
-    <span ng-i18next>
-      [i18next]({num: numSelectedShown})avAdmin.census.modals.activatePeopleBody
-    </span>
+  <p ng-i18next>
+    [i18next]({num: numSelectedShown})avAdmin.census.modals.activatePeopleBody
   </p>
+  <label for="activate-comment" class="control-label" ng-i18next>avAdmin.census.modals.comment</label>
+  <textarea id="activate-comment" class="form-control" rows="2" maxlength="255" ng-model="comment.activateComment"></textarea>
 </div>
 <div class="modal-footer">
   <button class="btn btn-warning" ng-click="ok()" ng-i18next>

--- a/avAdmin/admin-directives/elcensus/confirm-activate-people-modal.js
+++ b/avAdmin/admin-directives/elcensus/confirm-activate-people-modal.js
@@ -17,8 +17,9 @@
 
 angular.module('avAdmin')
   .controller('ConfirmActivatePeopleModal',
-    function($scope, $modalInstance, election, numSelectedShown) {
+    function($scope, $modalInstance, election, comment, numSelectedShown) {
       $scope.election = election;
+      $scope.comment = comment;
       $scope.numSelectedShown = numSelectedShown;
       $scope.ok = function () {
         $modalInstance.close();

--- a/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.html
+++ b/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.html
@@ -13,7 +13,7 @@
     [i18next]({num: numSelectedShown})avAdmin.census.modals.deactivatePeopleBody
   </p>
   <label for="deactivate-comment" class="control-label" ng-i18next>avAdmin.census.modals.comment</label>
-  <textarea id="activate-comment" class="form-control" rows="2" maxlength="255" ng-bind="comment.deactivateComment"></textarea>
+  <textarea id="activate-comment" class="form-control" rows="2" maxlength="255" ng-model="comment.deactivateComment"></textarea>
 </div>
 <div class="modal-footer">
   <button class="btn btn-danger" ng-click="ok()" ng-i18next>

--- a/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.html
+++ b/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.html
@@ -9,11 +9,11 @@
   </h4>
 </div>
 <div class="modal-body">
-  <p>
-    <span ng-i18next>
-      [i18next]({num: numSelectedShown})avAdmin.census.modals.deactivatePeopleBody
-    </span>
+  <p ng-i18next>
+    [i18next]({num: numSelectedShown})avAdmin.census.modals.deactivatePeopleBody
   </p>
+  <label for="deactivate-comment" class="control-label" ng-i18next>avAdmin.census.modals.comment</label>
+  <textarea id="activate-comment" class="form-control" rows="2" maxlength="255" ng-bind="comment.deactivateComment"></textarea>
 </div>
 <div class="modal-footer">
   <button class="btn btn-danger" ng-click="ok()" ng-i18next>

--- a/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.js
+++ b/avAdmin/admin-directives/elcensus/confirm-deactivate-people-modal.js
@@ -17,8 +17,9 @@
 
 angular.module('avAdmin')
   .controller('ConfirmDeactivatePeopleModal',
-    function($scope, $modalInstance, election, numSelectedShown) {
+    function($scope, $modalInstance, election, comment, numSelectedShown) {
       $scope.election = election;
+      $scope.comment = comment;
       $scope.numSelectedShown = numSelectedShown;
       $scope.ok = function () {
         $modalInstance.close();

--- a/avAdmin/admin-directives/elcensus/elcensus.js
+++ b/avAdmin/admin-directives/elcensus/elcensus.js
@@ -340,6 +340,7 @@ angular.module('avAdmin')
           Authmethod.activateUsersIds(scope.election.id, scope.election, user_ids, comment)
           .success(function(r) {
             scope.loading = false;
+            scope.comment.activateComment = "";
             scope.msg = "avAdmin.census.activatedCensusSuccessfully";
             scope.reloadCensus();
           })
@@ -354,6 +355,7 @@ angular.module('avAdmin')
           Authmethod.deactivateUsersIds(scope.election.id, scope.election, user_ids, comment)
           .success(function(r) {
             scope.loading = false;
+            scope.comment.deactivateComment = "";
             scope.msg = "avAdmin.census.activatedCensusSuccessfully";
             scope.reloadCensus();
           })

--- a/avAdmin/admin-directives/elcensus/elcensus.js
+++ b/avAdmin/admin-directives/elcensus/elcensus.js
@@ -54,6 +54,10 @@ angular.module('avAdmin')
       scope.resizeSensor = null;
       scope.helpurl = ConfigService.helpUrl;
       scope.showSuccessAction = ConfigService.showSuccessAction;
+      scope.comment = {
+        activateComment: "",
+        deactivateComment: ""
+      };
 
       scope.goNext = NextButtonService.goNext;
 
@@ -106,6 +110,7 @@ angular.module('avAdmin')
               controller: "ConfirmActivatePeopleModal",
               size: 'lg',
               resolve: {
+                comment: function () { return scope.comment; },
                 election: function () { return scope.election; },
                 numSelectedShown: function() {
                   return scope.numSelected(scope.shown());
@@ -126,6 +131,7 @@ angular.module('avAdmin')
               controller: "ConfirmDeactivatePeopleModal",
               size: 'lg',
               resolve: {
+                comment: function () { return scope.comment; },
                 election: function () { return scope.election; },
                 numSelectedShown: function() {
                   return scope.numSelected(scope.shown());
@@ -181,6 +187,7 @@ angular.module('avAdmin')
               controller: "ConfirmActivatePeopleModal",
               size: 'lg',
               resolve: {
+                comment: function () { return scope.comment; },
                 election: function () { return scope.election; },
                 numSelectedShown: function() {
                   return scope.numSelected(scope.shown());
@@ -200,6 +207,7 @@ angular.module('avAdmin')
               controller: "ConfirmDeactivatePeopleModal",
               size: 'lg',
               resolve: {
+                comment: function () { return scope.comment; },
                 election: function () { return scope.election; },
                 numSelectedShown: function() {
                   return scope.numSelected(scope.shown());
@@ -328,7 +336,8 @@ angular.module('avAdmin')
       function activateSelected() {
         var selectedList = scope.selected(scope.shown());
           var user_ids = _.pluck(selectedList, "id");
-          Authmethod.activateUsersIds(scope.election.id, scope.election, user_ids)
+          var comment = scope.comment.activateComment;
+          Authmethod.activateUsersIds(scope.election.id, scope.election, user_ids, comment)
           .success(function(r) {
             scope.loading = false;
             scope.msg = "avAdmin.census.activatedCensusSuccessfully";
@@ -341,7 +350,8 @@ angular.module('avAdmin')
       function deactivateSelected() {
         var selectedList = scope.selected(scope.shown());
           var user_ids = _.pluck(selectedList, "id");
-          Authmethod.deactivateUsersIds(scope.election.id, scope.election, user_ids)
+          var comment = scope.comment.deactivateComment;
+          Authmethod.deactivateUsersIds(scope.election.id, scope.election, user_ids, comment)
           .success(function(r) {
             scope.loading = false;
             scope.msg = "avAdmin.census.activatedCensusSuccessfully";

--- a/avAdmin/admin-directives/elcensus/elcensus.less
+++ b/avAdmin/admin-directives/elcensus/elcensus.less
@@ -129,8 +129,11 @@
     opacity: 1;
     transition: opacity 0.5s;
   }
+
 }
 
 .export-all-census-modal progressbar {
   margin-top: 15px;
 }
+
+#activate-comment, #deactivate-comment { min-height: auto; }

--- a/locales/en.json
+++ b/locales/en.json
@@ -389,6 +389,7 @@
         },
 
         "modals": {
+          "comment": "Comment",
           "csvLoadingHeader": "Uploading CSV to census",
           "csvLoadingBody": "Please click on the start upload button to add the users from the CSV to the census. Please wait until the process is finished and don't close this window.",
           "csvLoadingStartButton": "Start upload NOW",

--- a/locales/es.json
+++ b/locales/es.json
@@ -358,6 +358,7 @@
         "fields": {"label": "Campos extra", "placeholder": "Campos extra del votante"},
 
         "modals": {
+          "comment": "Observaciones",
           "csvLoadingHeader": "Uploading CSV to census",
           "csvLoadingBody": "Please click on the start upload button to add the users from the CSV to the census. Please wait until the process is finished and don't close this window.",
           "csvLoadingStartButton": "Start upload NOW",


### PR DESCRIPTION
This patch allows comments for activate and deactivate actions. A
textarea is available in the activate action and the content of that
will go as comment.

To show the comment in the activity log I've to change a little the
code because the angular template always resolve the {{obj.metadata.comment}}
as undefined, I don't know why, so I've added other attr to obj called
metadatacomment.

This PR depends on: https://github.com/agoravoting/agora-gui-common/pull/85