### PR TITLE
Add cumulative voting support

### DIFF
--- a/avAdmin/admin-directives/question/question.html
+++ b/avAdmin/admin-directives/question/question.html
@@ -294,16 +294,89 @@
                     <p class="text-muted" ng-i18next>
                         avAdmin.questions.layout.placeholder
                     </p>
+                    <p ng-if="q.tally_type === 'cumulative'" class="text-info" ng-i18next>
+                        avAdmin.questions.layout.cumulative-tally-help
+                    </p>
+
                     <div class="radio" ng-repeat="o in layouts">
                         <label>
                             <input
                               type="radio"
                               name="layout"
-                              ng-disabled="!electionEditable()"
+                              ng-disabled="!electionEditable() || !layoutSelectable(o)"
                               value="{{ o }}"
                               ng-model="q.layout"/>
-                            <span ng-i18next="avAdmin.questions.layout.{{ o }}"></span>
+                            <span
+                                ng-class="{'text-muted': !layoutSelectable(o)}"
+                                ng-i18next="avAdmin.questions.layout.{{ o }}">
+                            </span>
                         </label>
+                    </div>
+            </div>
+
+            <!-- cumulative_number_of_checkboxes extra options -->
+            <div
+              ng-if="q.tally_type === 'cumulative'"
+              av-abstract-setting
+              collapsable="true"
+              expanded="false"
+              short-value="{{ q.extra_options.cumulative_number_of_checkboxes }}"
+              title="avAdmin.cumulative.number_of_checkboxes.title"
+              for="number-of-checkboxes"
+              description=""
+              help-path="election/question-shuffle-categories/">
+
+                    <p class="text-muted" ng-i18next> avAdmin.cumulative.number_of_checkboxes.text </p>
+                    <div class="input-group col-xs-2">
+                      <span class="input-group-btn">
+                        <button
+                          class="btn btn-default"
+                          type="button"
+                          ng-disabled="!electionEditable()"
+                          ng-click="incCumulativeCheck(-1)">
+                            <span class="glyphicon glyphicon-minus" aria-hidden="true"></span>
+                        </button>
+                      </span>
+                      <div
+                        av-int-field
+                        int-data="q.extra_options.cumulative_number_of_checkboxes">
+                      </div>
+                      <input
+                        type="text"
+                        id="max"
+                        name="max"
+                        av-number-input
+                        min=0
+                        step=1
+                        class="form-control"
+                        ng-disabled="!electionEditable()"
+                        ui-keypress="{
+                          37: 'incCumulativeCheck(-1)',
+                          38: 'incCumulativeCheck(1)',
+                          39: 'incCumulativeCheck(1)',
+                          40: 'incCumulativeCheck(-1)'
+                        }"
+                        ui-validate="{ min: '$value >= 1'}"
+                        ui-validate-watch="'q.extra_options.cumulative_number_of_checkboxes'"
+                        ng-model="q.extra_options.cumulative_number_of_checkboxes"
+                        required/>
+                      <span class="input-group-btn">
+                        <button
+                          class="btn btn-default"
+                          type="button"
+                          ng-disabled="!electionEditable()"
+                          ng-click="incCumulativeCheck(1)">
+                            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                        </button>
+                      </span>
+                    </div>
+                    <div class="col-xs-10 input-error">
+                      <span
+                        class="error text-brand-danger"
+                        ng-show="!!qform{{$index}}.max.$error.min"
+                        ng-i18next>
+                        [i18next]avAdmin.questions.max.minError
+                      </span>
                     </div>
             </div>
 

--- a/avAdmin/admin-directives/question/question.js
+++ b/avAdmin/admin-directives/question/question.js
@@ -85,7 +85,28 @@ angular.module('avAdmin')
            scope.q.min = 0;
            scope.q.max = 62;
         }
+
+        if ("cumulative" === newValue) {
+          // Cumulative is only available on simultaneous-questions layaout
+          scope.q.layout = "simultaneous-questions";
+        }
       });
+
+      scope.layoutSelectable = function(l) {
+        // Cumulative is only available on simultaneous-questions layaout
+        if (scope.q.tally_type === "cumulative") {
+          var checks = scope.q.extra_options.cumulative_number_of_checkboxes;
+          scope.q.extra_options.cumulative_number_of_checkboxes = checks || 1;
+
+          return l === "simultaneous-questions";
+        }
+
+        return true;
+      };
+
+      scope.incCumulativeCheck = function(n) {
+        scope.q.extra_options.cumulative_number_of_checkboxes += n;
+      };
 
       scope.$watch("internal.shuffle_opts_policy", function (newValue, oldValue) {
         if ('shuffle-all' === newValue) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,7 +26,7 @@
     "poweredBy": "Powered by <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>",
     "shareLink": "Tweet this election!",
     "votingSystem": "Voting System",
-    "votings": {"plurality-at-large": "Plurality at large", "borda-nauru": "Nauru's Borda Count or Borda Dowdall (1/n)", "borda": "Borda Count (traditional)", "pairwise-beta": "Pairwise (beta-distribution)", "desborda": "DesBorda"}
+    "votings": {"plurality-at-large": "Plurality at large", "borda-nauru": "Nauru's Borda Count or Borda Dowdall (1/n)", "borda": "Borda Count (traditional)", "pairwise-beta": "Pairwise (beta-distribution)", "desborda": "DesBorda", "cumulative": "Cumulative voting"}
   },
   "avAdmin": {
     "profile": {
@@ -212,6 +212,12 @@
     },
     "setting": {
       "helpTooltip": "Click to expand/collapse help text about this setting"
+    },
+    "cumulative": {
+      "number_of_checkboxes": {
+        "title": "Number of checkboxes",
+        "text": "Number of checkboxes to show for each answer"
+      }
     },
     "shuffling_policy": {
       "categories_label": "Ramdomize categories",
@@ -513,7 +519,8 @@
           "accordion": "Normal",
           "circles": "Images with details",
           "conditional-accordion": "Conditional accordion",
-          "simultaneous-questions": "Simultaneous questions"
+          "simultaneous-questions": "Simultaneous questions",
+          "cumulative-tally-help": "The tally method cummulative is only supported for simultaneous questions"
         },
         "option": {
           "textFieldLabel": "Text",


### PR DESCRIPTION
This patch adds the cumulative voting tally type.

The cumulative tally_type will only be supported by the
simultaneous questions layout, so this patch ensure that the user
can only select the correct layout/tally_type combination and
shows a descriptive message for the user.

A new extra_option is also added so the
cumulative_number_of_questions could be configured in the admin
interface.