### PR TITLE
fix edit send-auth messages in dashboard and allow edit send-auth for  email-otp

### DIFF
--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.html
@@ -61,7 +61,7 @@
         <div
           ng-click="editAuthCodes()"
           class="preview-data preview-body"
-          ng-bind="parseMessage(election.census.config.msg)">
+          ng-bind="parseMessage(censusConfig.msg)">
         </div>
       </div>
     </div>
@@ -78,7 +78,7 @@
         <div
           ng-click="editAuthCodes()"
           class="preview-data"
-          ng-bind="parseMessage(election.census.config.subject)">
+          ng-bind="parseMessage(censusConfig.subject)">
         </div>
       </div>
     </div>
@@ -93,7 +93,7 @@
         <div
           ng-click="editAuthCodes()"
           class="preview-data preview-body"
-          ng-bind="parseMessage(election.census.config.msg)">
+          ng-bind="parseMessage(censusConfig.msg)">
         </div>
       </div>
     </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal-confirm.js
@@ -39,6 +39,7 @@ angular.module('avAdmin')
       $scope.user_ids = user_ids;
       $scope.imsure = false;
       $scope.steps = SendMsg.steps;
+      $scope.censusConfig = SendMsg.censusConfig;
       $scope.loading = false;
       $scope.numVoters = (!!SendMsg.user_ids) ? SendMsg.user_ids.length : $scope.election.auth.census;
       $scope.helpurl = ConfigService.helpUrl;
@@ -160,7 +161,7 @@ angular.module('avAdmin')
         var re1 = /__URL__/;
         var re3 = /__URL2__/;
         var re2 = /__CODE__/;
-        var msg = election.census.config.msg;
+        var msg = $scope.censusConfig.msg;
 
         return ((msg.match(re1) && msg.match(re2)) || msg.match(re3));
       }

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.html
@@ -5,7 +5,11 @@
     <span class="title" ng-i18next>
       [i18next]({step:steps.current, total:steps.total})avAdmin.dashboard.modals.sendAuthCodes.editMessageStep.header
     </span>
-    <button type="button" class="close pull-right" ng-click="cancel()">×</button>
+    <button
+      type="button"
+      class="close pull-right"
+      ng-click="cancel()"
+    >×</button>
   </h4>
 </div>
 <div class="modal-body send-auth-codes-modal">
@@ -49,7 +53,9 @@
        </div>
     </div>
     <div class="row">
-      <div ng-if="'sms' === selected_auth_method.ref || 'sms-otp' === selected_auth_method.ref">
+      <div 
+        ng-if="'sms' === selected_auth_method.ref || 'sms-otp' === selected_auth_method.ref"
+      >
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right"
@@ -60,19 +66,27 @@
                   <p class="text-muted" ng-if="slug_text.length > 0" ng-i18next>
                     [i18next]({slug_list:slug_text})avAdmin.auth.slugKeys
                   </p>
-                  <textarea class="form-control" ng-model="election.census.config.msg"></textarea>
+                  <textarea 
+                    class="form-control" 
+                    ng-model="censusConfig.msg"
+                  >
+                  </textarea>
               </div>
           </div>
       </div>
       <!-- Email conf -->
-      <div ng-if="'email' === selected_auth_method.ref">
+      <div ng-if="'email' === selected_auth_method.ref || 'email-otp' === selected_auth_method.ref">
           <div class="form-group">
               <label
                 class="col-xs-3 control-label text-right padding-top-input"
                 ng-i18next="avAdmin.auth.emailsub">
               </label>
               <div class="col-xs-9">
-                  <input type="text" class="form-control" ng-model="election.census.config.subject"/>
+                  <input
+                    type="text"
+                    class="form-control"
+                    ng-model="censusConfig.subject" 
+                  />
               </div>
           </div>
           <div class="clearfix"></div>
@@ -83,10 +97,18 @@
               </label>
               <div class="col-xs-9">
                   <p class="text-muted" ng-i18next> avAdmin.auth.emailtemp </p>
-                  <p class="text-muted" ng-if="slug_text.length > 0" ng-i18next>
+                  <p 
+                    class="text-muted"
+                    ng-if="slug_text.length > 0"
+                    ng-i18next
+                  >
                     [i18next]({slug_list:slug_text})avAdmin.auth.slugKeys
                   </p>
-                  <textarea class="form-control" ng-model="election.census.config.msg"></textarea>
+                  <textarea 
+                    class="form-control"
+                    ng-model="censusConfig.msg"
+                  >
+                  </textarea>
               </div>
           </div>
       </div>

--- a/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
+++ b/avAdmin/admin-directives/dashboard/send-auth-codes-modal.js
@@ -1,6 +1,6 @@
 /**
  * This file is part of agora-gui-admin.
- * Copyright (C) 2015-2016  Agora Voting SL <agora@agoravoting.com>
+ * Copyright (C) 2015-2021  Agora Voting SL <agora@agoravoting.com>
 
  * agora-gui-admin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -15,15 +15,25 @@
  * along with agora-gui-admin.  If not, see <http://www.gnu.org/licenses/>.
 **/
 
-angular.module('avAdmin')
-  .controller('SendAuthCodesModal',
-    function($scope, $modalInstance, SendMsg, ConfigService, election, user_ids) {
+angular
+  .module('avAdmin')
+  .controller(
+    'SendAuthCodesModal',
+    function(
+      $scope,
+      $modalInstance,
+      SendMsg,
+      ConfigService,
+      election,
+      user_ids
+    ) {
       $scope.election = election;
       $scope.auth = ['email', 'sms'];
       $scope.selectable_auth_method = SendMsg.selectable_auth_method;
       $scope.selected_auth_method = { ref: SendMsg.selected_auth_method };
       $scope.user_ids = user_ids;
       $scope.steps = SendMsg.steps;
+      $scope.censusConfig = SendMsg.censusConfig;
       $scope.helpurl = ConfigService.helpUrl;
       var slug_text = "";
       for (var i = 0; i < SendMsg.slug_list.length; i++) {

--- a/avAdmin/elections-api-service.js
+++ b/avAdmin/elections-api-service.js
@@ -169,17 +169,13 @@ angular.module('avAdmin')
           el.census.extra_fields = electionAuth.extra_fields;
           el.census.admin_fields = electionAuth.admin_fields;
           el.census.census = electionAuth.census;
-          if(!!electionAuth.num_successful_logins_allowed || 0 === electionAuth.num_successful_logins_allowed) {
+          if(
+            !!electionAuth.num_successful_logins_allowed || 
+            0 === electionAuth.num_successful_logins_allowed
+          ) {
             el.num_successful_logins_allowed = electionAuth.num_successful_logins_allowed;
           }
-
-          var newConf = electionAuth.auth_method_config.config;
-          // not updating msgs if are modified
-          if (el.census.config && el.census.config.msg) {
-              newConf.msg = el.census.config.msg;
-              newConf.subject = el.census.config.subject;
-          }
-          el.census.config = newConf;
+          el.census.config = electionAuth.auth_method_config.config;
 
           // make it easy to get children election' names
           el.childrenElectionNames = {};

--- a/avAdmin/send-messages-service.js
+++ b/avAdmin/send-messages-service.js
@@ -1,6 +1,6 @@
 /**
  * This file is part of agora-gui-admin.
- * Copyright (C) 2015-2016  Agora Voting SL <agora@agoravoting.com>
+ * Copyright (C) 2015-2021  Agora Voting SL <agora@agoravoting.com>
 
  * agora-gui-admin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -18,8 +18,9 @@
 /**
  * Service to manage the send authentication codes modal steps.
  */
-angular.module('avAdmin')
-  .factory('SendMsg', function($q, $modal, Authmethod, Plugins, ElectionsApi)
+angular
+  .module('avAdmin')
+  .factory('SendMsg', function($q, $modal, Authmethod, Plugins)
   {
     // These is the base data of this service
     var service = {
@@ -87,6 +88,12 @@ angular.module('avAdmin')
     {
         service.skipEditDialogFlag = false;
         service.election = el;
+        if (!service.censusConfig)
+        {
+          service.censusConfig = angular.copy(
+            el.census.config
+          );
+        }
         service.slug_list = get_slugs(el);
     };
 
@@ -255,9 +262,11 @@ angular.module('avAdmin')
         {el: service.election, ids: service.user_ids}))
       {
           // send asynchronously the authentication codes
+          var electionCopy = angular.copy(service.election);
+          electionCopy.census.config = service.censusConfig;
           Authmethod.sendAuthCodes(
-            service.election.id,
-            service.election,
+            electionCopy.id,
+            electionCopy,
             service.user_ids,
             service.selected_auth_method,
             service.extra


### PR DESCRIPTION
Source: PR (#236)

* trying to ensure that both the original census message is not overridden by the default, and that it's preserved if edited in the dialog

* fixing build

* allow editing message in email-otp

* saving msg and subject for send message modals in SendMsg service instead