### PR TITLE
Improve auto-generated release-notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: 💥 Breaking Changes
+      labels:
+        - breaking-change
+    - title: 🚀 New Features
+      labels:
+        - enhancement
+    - title: 🛠 Bug Fixes
+      labels:
+        - bug
+    - title: 🛡 Security Updates
+      labels:
+        - dependencies
+        - security-update
+    - title: 📖 Documentation Improvements
+      labels:
+        - doc
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Adding an initial  file similar to https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration

This will allow the auto-generated release-notes for new project releases to be more useful, by grouping and categorizing all PRs.
