### PR TITLE
Delayed children election info setting during election creation

### DIFF
--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1018,7 +1018,7 @@ angular.module('avAdmin')
                 num_successful_logins_allowed: el.num_successful_logins_allowed,
                 allow_public_census_query: el.allow_public_census_query,
                 hide_default_login_lookup_field: el.hide_default_login_lookup_field,
-                parent_id: el.parent_id,
+                parent_id: null,
                 children_election_info: null
             };
 
@@ -1108,7 +1108,13 @@ angular.module('avAdmin')
             )
           );
           Authmethod
-            .editChildrenParent(el.children_election_info, el.id)
+            .editChildrenParent(
+              {
+                parent_id: el.parent_id,
+                children_election_info: el.children_election_info
+              },
+              el.id
+            )
             .then(
               function(_data)
               {

--- a/avAdmin/admin-directives/create/create.js
+++ b/avAdmin/admin-directives/create/create.js
@@ -1019,7 +1019,7 @@ angular.module('avAdmin')
                 allow_public_census_query: el.allow_public_census_query,
                 hide_default_login_lookup_field: el.hide_default_login_lookup_field,
                 parent_id: el.parent_id,
-                children_election_info: el.children_election_info
+                children_election_info: null
             };
 
             // Set election id if existing in election configuration
@@ -1096,6 +1096,29 @@ angular.module('avAdmin')
             return deferred.promise;
         }
 
+        function setChildrenElectionInfo(el)
+        {
+          console.log("setting children election info for election " + el.title);
+          var deferred = $q.defer();
+
+          logInfo(
+            $i18next(
+              'avAdmin.create.setChildrenElectionInfo',
+              {title: el.title, id: el.id}
+            )
+          );
+          Authmethod
+            .editChildrenParent(el.children_election_info, el.id)
+            .then(
+              function(_data)
+              {
+                deferred.resolve(el);
+              }
+            )
+            .catch(deferred.reject);
+          return deferred.promise;
+        }
+
         function registerElection(el) {
             console.log("registering election " + el.title);
 
@@ -1156,7 +1179,7 @@ angular.module('avAdmin')
             });
         }
 
-        function addCensusAndCreatePublicKeys(electionIndex) 
+        function secondElectionsStage(electionIndex) 
         {
           var deferred = $q.defer();
           if (electionIndex === scope.elections.length) 
@@ -1169,13 +1192,14 @@ angular.module('avAdmin')
 
           var promise = deferred.promise;
           promise = promise
+            .then(setChildrenElectionInfo)
             .then(addCensus)
             .then(createElection)
             .then(function(election) {
               console.log("waiting for election " + election.title);
               waitForCreated(election.id, function () {
                 DraftElection.eraseDraft();
-                addCensusAndCreatePublicKeys(electionIndex + 1);
+                secondElectionsStage(electionIndex + 1);
               });
             })
             .catch(function(error) {
@@ -1190,11 +1214,13 @@ angular.module('avAdmin')
         {
           var deferred = $q.defer();
 
-          // After creating the auth events, and registering all the elections 
-          // in agora_elections, we proceed to add census and create the 
-          // election public keys
+          // After creating the auth events and registering all the elections 
+          // in agora_elections, we proceed to:
+          // - set children election info
+          // - add census
+          // - create election public keys
           if (electionIndex === scope.elections.length) {
-            addCensusAndCreatePublicKeys(0);
+            secondElectionsStage(0);
             return;
           }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -724,6 +724,7 @@
         "summary__plural": "Summary: creating __num__ elections",
         "create": "Create the elections",
         "creating": "Creating the authentication for election __title__",
+        "setChildrenElectionInfo": "Setting the children election info for election __title__",
         "census": "Adding the census (id: __id__) __title__",
         "ballot_boxes": "Adding ballot boxes (id: __id__) __title__",
         "reg": "Registering the election (id: __id__) __title__",


### PR DESCRIPTION
In the election creation admin page, when creating [parent-children elections](https://agoravoting.github.io/admin-manual/docs/advanced-elections/parent-and-children-elections) sometimes it fails because parent is not created yet when setting the [children election info](https://agoravoting.github.io/admin-manual/docs/file-formats/election-creation-json#election-children_election_info). This can be easily fixed by first creating the auth-event and registering all the elections in the backend, and only afterwards setting the children-election-info.