### PR TITLE
Delayed children election info setting during election creation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -785,6 +785,7 @@
         "summary__plural": "Summary: creating __num__ elections",
         "create": "Create the elections",
         "creating": "Creating the authentication for election __title__",
+        "setChildrenElectionInfo": "Setting the children election info for election __title__",
         "census": "Adding the census (id: __id__) __title__",
         "ballot_boxes": "Adding ballot boxes (id: __id__) __title__",
         "reg": "Registering the election (id: __id__) __title__",


### PR DESCRIPTION
* Delayed children election info setting during election creation

In the election creation admin page, when creating [parent-children elections](https://agoravoting.github.io/admin-manual/docs/advanced-elections/parent-and-children-elections) sometimes it fails because parent is not created yet when setting the [children election info](https://agoravoting.github.io/admin-manual/docs/file-formats/election-creation-json#election-children_election_info). This can be easily fixed by first creating the auth-event and registering all the elections in the backend, and only afterwards setting the children-election-info.

* also delay setting parent id