### PR TITLE
fixing ballot box permissions detection in admin-controller

### DIFF
--- a/avAdmin/admin-controller/admin-controller.js
+++ b/avAdmin/admin-controller/admin-controller.js
@@ -254,7 +254,10 @@ angular
                       function (perm) {
                         if (
                           el.census.has_ballot_boxes &&
-                          perm.indexOf('list-ballot-boxes') !== -1
+                          (
+                            perm.indexOf('list-ballot-boxes') !== -1 ||
+                            perm.indexOf('edit') !== -1
+                          )
                         ) {
                           $scope.sidebarlinks.splice(
                             1, 


### PR DESCRIPTION
It was not detecting that `edit` perms as equivalent to `list-ballot-boxes`.